### PR TITLE
Added filter for filtering events using METFilters

### DIFF
--- a/Compile/interface/ZJetSettings.h
+++ b/Compile/interface/ZJetSettings.h
@@ -90,6 +90,7 @@ class ZJetSettings : public KappaSettings
     IMPL_SETTING(std::string, CutJetID)
     IMPL_SETTING(std::string, CutJetIDVersion)
     IMPL_SETTING(unsigned, CutJetIDFirstNJets)
+    IMPL_SETTING_STRINGLIST_DEFAULT(METFilterNames, {})
 
     // LeptonSFProducer
     IMPL_SETTING(std::string, LeptonIDSFRootfile)

--- a/Compile/src/ZJetFactory.cc
+++ b/Compile/src/ZJetFactory.cc
@@ -162,6 +162,8 @@ FilterBaseUntemplated* ZJetFactory::createFilter(std::string const& id)
         return new ValidZCut();
     else if (id == ValidGenZCut().GetFilterId())
         return new ValidGenZCut();
+    else if (id == METFiltersFilter().GetFilterId())
+        return new METFiltersFilter();
     else
         return KappaFactory::createFilter(id);
 }

--- a/cfg/python/defaultconfig.py
+++ b/cfg/python/defaultconfig.py
@@ -103,6 +103,8 @@ def getBaseConfig(tagged=False, **kwargs):
         'EventMetadata' : 'eventInfo',
         'LumiMetadata' : 'lumiInfo',
         'VertexSummary': 'goodOfflinePrimaryVerticesSummary',
+        'TriggerInfos': 'triggerObjectMetadata',
+        'TriggerObjects': 'triggerObjects'
     }
     if tagged:
         cfg['Pipelines']['default']['Quantities'] += ['jet1btagpf','jet1btag', 'jet1qgtag']


### PR DESCRIPTION
If an event does not pass the METFilters, defined by the setting `METFilterNames`, the filter rejects it.
I added the required branches for the trigger objects and the trigger object metadata to the default config.