### PR TITLE
[ZJetGenWeightProducer] Implemented default behaviour for weight filling

### DIFF
--- a/Compile/interface/Producers/ZJetGenWeightProducer.h
+++ b/Compile/interface/Producers/ZJetGenWeightProducer.h
@@ -21,7 +21,7 @@ public:
 
 	void Init(ZJetSettings const& settings) override;
 
-    void OnLumi(ZJetEvent const& event, ZJetSettings const& settings) override;
+    void OnRun(ZJetEvent const& event, ZJetSettings const& settings) override;
 
 	void Produce(ZJetEvent const& event, ZJetProduct& product,
 	                     ZJetSettings const& settings) const override;
@@ -30,5 +30,6 @@ public:
 private:
     std::vector<std::string> m_requestedNames;
     std::map<std::string, size_t> m_lheWeightNamesMap;
+    bool m_isDefaultWeight;
 
 };


### PR DESCRIPTION
This will achieve backwards compatibility for running on old skims, which have not skimmed the genWeight information. It closes #56  .