### PR TITLE
Prevent JER smearing in data and check for negative smearing factors.

### DIFF
--- a/Compile/src/Producers/JERSmearer.cc
+++ b/Compile/src/Producers/JERSmearer.cc
@@ -9,6 +9,10 @@ void JERSmearer::Init(ZJetSettings const& settings) {
 
     ZJetProducerBase::Init(settings);
 
+    // check explicitly if running on MC
+    if (settings.GetInputIsData())
+        LOG(FATAL) << "[JERSmearer] Attempt to smear jets with JER in data! Aborting.";
+
     // convert usual algo name (ak5PFJetsCHS) to txt file algo name (AK5PFchs)
     std::string jetName = "Jets";
     if (settings.GetTaggedJets().find("Tagged") != std::string::npos)
@@ -33,10 +37,7 @@ void JERSmearer::Init(ZJetSettings const& settings) {
 
     // get and validate smearing method configuration
     if (KappaTools::tolower(settings.GetJERMethod()) == "hybrid") {
-        if (settings.GetInputIsData())
-            LOG(FATAL) << "[JERSmearer] JER smearing method hybrid not possible for data!!!";
-        else
-            m_smearingMethod = JERSmearer::SmearingMethod::HYBRID;
+        m_smearingMethod = JERSmearer::SmearingMethod::HYBRID;
     }
     else if (KappaTools::tolower(settings.GetJERMethod()) == "stochastic") {
         m_smearingMethod = JERSmearer::SmearingMethod::STOCHASTIC;
@@ -66,65 +67,43 @@ void JERSmearer::Produce(ZJetEvent const& event,
                          ZJetSettings const& settings) const {
 
     // iterate over all jet correction levels
-    if (settings.GetInputIsData()) {
-        for (std::map<std::string, std::vector<std::shared_ptr<KJet>>>::const_iterator itlevel = product.m_correctedZJets.begin();
-             itlevel != product.m_correctedZJets.end();
-             ++itlevel) {
-    
-            // shortcuts for convenience
-            auto& recoJets = product.m_correctedZJets[itlevel->first];
-            // go through all reco jets
-            for (size_t iJet = 0; iJet < recoJets.size(); ++iJet) {
-                // retrieve the (relative) pT resolution and the resolution scale factor
-                double jetResolution = m_jetResolution->getResolution({
-                    {JME::Binning::JetPt, recoJets[iJet]->p4.Pt()},
-                    {JME::Binning::JetEta, recoJets[iJet]->p4.Eta()},
-                    {JME::Binning::Rho, event.m_pileupDensity->rho}
-                });
-                // compute and apply the pT smearing factor
-                recoJets[iJet]->p4 *= 1 + std::normal_distribution<>(0, jetResolution)(m_randomNumberGenerator);
+    for (std::map<std::string, std::vector<std::shared_ptr<KJet>>>::const_iterator itlevel = product.m_correctedZJets.begin();
+         itlevel != product.m_correctedZJets.end();
+         ++itlevel) {
+
+        // shortcuts for convenience
+        auto& recoJets = product.m_correctedZJets[itlevel->first];
+        const auto& matchedGenJetIndices = product.m_matchedGenJets[itlevel->first];
+        // go through all reco jets
+        for (size_t iJet = 0; iJet < recoJets.size(); ++iJet) {
+            // retrieve the (relative) pT resolution and the resolution scale factor
+            double jetResolution = m_jetResolution->getResolution({
+                {JME::Binning::JetPt, recoJets[iJet]->p4.Pt()},
+                {JME::Binning::JetEta, recoJets[iJet]->p4.Eta()},
+                {JME::Binning::Rho, event.m_pileupDensity->rho}
+            });
+            double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
+                {JME::Binning::JetEta, recoJets[iJet]->p4.Eta()}
+            }, Variation::NOMINAL);
+            // get and validate matched gen jet
+            const KLV* matchedGenJet = nullptr;
+            if (matchedGenJetIndices[iJet] >= 0) {
+                matchedGenJet = product.m_simpleGenJets[matchedGenJetIndices[iJet]];
+
+                // invalidate match if additional pT-criterion is not met
+                if (std::abs(recoJets[iJet]->p4.Pt() - matchedGenJet->p4.Pt()) > 3 * jetResolution * recoJets[iJet]->p4.Pt()) {
+                    matchedGenJet = nullptr;
+                }
             }
-        }
-    }
-    else {
-        for (std::map<std::string, std::vector<std::shared_ptr<KJet>>>::const_iterator itlevel = product.m_correctedZJets.begin();
-             itlevel != product.m_correctedZJets.end();
-             ++itlevel) {
-    
-            // shortcuts for convenience
-            auto& recoJets = product.m_correctedZJets[itlevel->first];
-            const auto& matchedGenJetIndices = product.m_matchedGenJets[itlevel->first];
-            // go through all reco jets
-            for (size_t iJet = 0; iJet < recoJets.size(); ++iJet) {
-                // retrieve the (relative) pT resolution and the resolution scale factor
-                double jetResolution = m_jetResolution->getResolution({
-                    {JME::Binning::JetPt, recoJets[iJet]->p4.Pt()},
-                    {JME::Binning::JetEta, recoJets[iJet]->p4.Eta()},
-                    {JME::Binning::Rho, event.m_pileupDensity->rho}
-                });
-                double jetResolutionScaleFactor = m_jetResolutionScaleFactor->getScaleFactor({
-                    {JME::Binning::JetEta, recoJets[iJet]->p4.Eta()}
-                }, Variation::NOMINAL);
-                // get and validate matched gen jet
-                const KLV* matchedGenJet = nullptr;
-                if (matchedGenJetIndices[iJet] >= 0) {
-                    matchedGenJet = product.m_simpleGenJets[matchedGenJetIndices[iJet]];
-    
-                    // invalidate match if additional pT-criterion is not met
-                    if (std::abs(recoJets[iJet]->p4.Pt() - matchedGenJet->p4.Pt()) > 3 * jetResolution * recoJets[iJet]->p4.Pt()) {
-                        matchedGenJet = nullptr;
-                    }
-                }
-    
-                // compute and apply the pT smearing factor
-                if ((matchedGenJet) && (m_smearingMethod == JERSmearer::SmearingMethod::HYBRID)) {
-                    // match found and hybrid method requested -> smear using scaling method
-                    recoJets[iJet]->p4 *= 1 + (jetResolutionScaleFactor - 1) * (recoJets[iJet]->p4.Pt() - matchedGenJet->p4.Pt())/recoJets[iJet]->p4.Pt();
-                }
-                else if ((m_smearingMethod == JERSmearer::SmearingMethod::STOCHASTIC) || (!matchedGenJet)) {
-                    // match not found or stochastic method requested -> draw pT smearing factor from a normal distribution
-                    recoJets[iJet]->p4 *= 1 + std::normal_distribution<>(0, jetResolution)(m_randomNumberGenerator) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
-                }
+
+            // compute and apply the pT smearing factor
+            if ((matchedGenJet) && (m_smearingMethod == JERSmearer::SmearingMethod::HYBRID)) {
+                // match found and hybrid method requested -> smear using scaling method
+                recoJets[iJet]->p4 *= 1 + (jetResolutionScaleFactor - 1) * (recoJets[iJet]->p4.Pt() - matchedGenJet->p4.Pt())/recoJets[iJet]->p4.Pt();
+            }
+            else if ((m_smearingMethod == JERSmearer::SmearingMethod::STOCHASTIC) || (!matchedGenJet)) {
+                // match not found or stochastic method requested -> draw pT smearing factor from a normal distribution
+                recoJets[iJet]->p4 *= 1 + std::normal_distribution<>(0, jetResolution)(m_randomNumberGenerator) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
             }
         }
     }

--- a/Compile/src/Producers/JERSmearer.cc
+++ b/Compile/src/Producers/JERSmearer.cc
@@ -97,14 +97,19 @@ void JERSmearer::Produce(ZJetEvent const& event,
             }
 
             // compute and apply the pT smearing factor
+            double jecSmearFactor = 1.0;
             if ((matchedGenJet) && (m_smearingMethod == JERSmearer::SmearingMethod::HYBRID)) {
                 // match found and hybrid method requested -> smear using scaling method
-                recoJets[iJet]->p4 *= 1 + (jetResolutionScaleFactor - 1) * (recoJets[iJet]->p4.Pt() - matchedGenJet->p4.Pt())/recoJets[iJet]->p4.Pt();
+                jecSmearFactor = 1 + (jetResolutionScaleFactor - 1) * (recoJets[iJet]->p4.Pt() - matchedGenJet->p4.Pt())/recoJets[iJet]->p4.Pt();
             }
             else if ((m_smearingMethod == JERSmearer::SmearingMethod::STOCHASTIC) || (!matchedGenJet)) {
                 // match not found or stochastic method requested -> draw pT smearing factor from a normal distribution
-                recoJets[iJet]->p4 *= 1 + std::normal_distribution<>(0, jetResolution)(m_randomNumberGenerator) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
+                jecSmearFactor = 1 + std::normal_distribution<>(0, jetResolution)(m_randomNumberGenerator) * std::sqrt(std::max(jetResolutionScaleFactor * jetResolutionScaleFactor - 1, 0.0));
             }
+
+            // apply factor (prevent negative values)
+            if (jecSmearFactor > 0)
+                recoJets[iJet]->p4 *= jecSmearFactor;
         }
     }
 }

--- a/Compile/src/Producers/JERSmearer.cc
+++ b/Compile/src/Producers/JERSmearer.cc
@@ -108,8 +108,7 @@ void JERSmearer::Produce(ZJetEvent const& event,
             }
 
             // apply factor (prevent negative values)
-            if (jecSmearFactor > 0)
-                recoJets[iJet]->p4 *= jecSmearFactor;
+            recoJets[iJet]->p4 *= (jecSmearFactor < 0) ? 0.0 : jecSmearFactor;
         }
     }
 }


### PR DESCRIPTION
Since there is currently no use case for using JER smearing in data, this PR introduces an explicit check in the `JERSmearer` and throws an exception if running on data.

In addition, a further check is introduced to prevent smearing the jet p4 with a negative factor. This should be rare, but it can occur in principle when using stochastic smearing, leading to an unwanted reversal of the jet direction. In this case, the jet p4 is not smeared.