### PR TITLE
Add pseudo hadd option using TChains

### DIFF
--- a/scripts/hadd_xrootd.py
+++ b/scripts/hadd_xrootd.py
@@ -3,63 +3,36 @@ import subprocess
 import sys
 import argparse
 
-
-def convert_srm_to_xrootd_path(path):
-    sites = { "srm://cmssrm-kit.gridka.de:8443/srm/managerv2?SFN=/pnfs/gridka.de/cms/disk-only/": "root://cmsxrootd-redirectors.gridka.de//"}
-    for site in sites.keys():
-        if path.find(site) is 0:
-            return sites[site]+path[len(site):]
-    return path
+try:
+    from xrootdglob import glob
+except ImportError:
+    print("Importing xrootd failed. Can't access files via xrootd.")
+    from glob import glob
 
 
-def get_filelist(xrootd_path):
-    print("Use pyxrootd tools")
-    print("xrootd path: %s" % xrootd_path)
-    gridpath = xrootd_path.replace("*.root", "")
-        
-    gridserver = 'root://' + gridpath.split("//")[1]
-    gridpath = '/' + gridpath.split("//")[2]
-    gridpath = gridpath.replace('\n', '')
-    print("server: %s"% gridserver)
-    print("path: %s"% gridpath)
-    from XRootD import client
-    from XRootD.client.flags import DirListFlags, OpenFlags, MkDirFlags, QueryCode
-    myclient = client.FileSystem(gridserver)
-    print('Getting file list from XRootD server')
-    status, listing = myclient.dirlist(gridpath, DirListFlags.LOCATE, timeout=10)
-    out_files = []
-    if listing is not None:
-            for entry in listing:
-                if entry.name.endswith('.root') and not entry.name == '':
-                        out_files.append(gridserver + '/' + gridpath + '/' + entry.name)
-            print("Successfully queried")
-    else:
-        print("XRootD path not accessable: %s", xrootd_path)
-    return out_files
-
-
-def main(xrootd_path, output):
-    filelist = get_filelist(convert_srm_to_xrootd_path(xrootd_path))
-    print("Filelist:\n")
-    for filename in filelist:
-        print("file: %s"% filename)
+def merge(target, filelist, overwrite):
+    command = ['hadd']
+    if overwrite:
+        command += ['-f']
     try:
-        subprocess.call(['hadd', output] + filelist)
-        #print(['hadd', output] + filelist)
-    except KeyboardInterrupt:                                                   
-        sys.exit(0) 
+        subprocess.check_call(command + [target] + filelist)
     except subprocess.CalledProcessError:                                       
-        print "hadd failed"                                        
-        sys.exit(1)  
+        print "hadd failed!"                                        
+        sys.exit(1) 
  
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument("-o", "--output", help="output root file", default="out.root")
-    parser.add_argument("-i", "--input", help="XRootD path e.g.  root://cmsxrootd-kit.gridka.de//store/user/mschnepf/Skimming/*.root", type=str)
+    parser.add_argument("TARGET", help="Output root file", type=str)
+    parser.add_argument("INPUT", help="Input root files or XRootD path e.g. root://cmsxrootd-kit.gridka.de//store/user/myuser/*.root", type=str, nargs='+')
+    parser.add_argument('-f', '--overwrite', help="overwrite an existing output file", action='store_true')
+    
     args = parser.parse_args()
-    output = args.output
-    path = args.input
-    #path = "root://cmsxrootd-redirectors.gridka.de//store/user/mschnepf/Skimming/WJets_TuneCP5_13TeV-pythia8_RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/*.root"
-    main(xrootd_path=path, output=output)
+    
+    target = args.TARGET
+    input_paths = args.INPUT
+    filelist = []
+    for path in input_paths:
+        filelist += glob(path)
+    merge(target, filelist, args.overwrite)
 

--- a/scripts/pseudo_hadd.py
+++ b/scripts/pseudo_hadd.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""
+Based on https://root.cern.ch/doc/master/hadd_8C_source.html
+Instead of adding TTrees to the TChain and merging it, add the files, so that we only create a proxy file.
+The original files need to be kept at the same path for this to work.
+"""
+
+
+import os
+import ROOT
+import argparse
+
+try:
+    from xrootdglob import glob
+except ImportError:
+    print("Importing xrootd failed. Can't access files via xrootd.")
+    from glob import glob
+
+def MergeRootFiles(target, sourcefiles, check=False):
+    path = target.GetPath().split(':')[-1]
+    path = path[1:]
+
+    first_source = ROOT.TFile.Open(sourcefiles[0], "READ")
+    first_source.cd(path)
+    current_sourcedir = ROOT.gDirectory
+    # gain time, do not add the objects in the list in memory
+    status = ROOT.TH1.AddDirectoryStatus()
+    ROOT.TH1.AddDirectory(ROOT.kFALSE)
+    keys = current_sourcedir.GetListOfKeys()
+
+    for key in keys:
+        # read object from first source file
+        first_source.cd(path)
+        obj = key.ReadObj()
+
+        if isinstance(obj, ROOT.TObjString):
+            for fname in sourcefiles:
+                f = ROOT.TFile.Open(fname, "READ")
+                f.cd(path)
+                key2 = ROOT.gDirectory.GetListOfKeys().FindObject(key.GetName())
+                string = key2.ReadObj().Clone()
+                f.Close()
+                target.cd()
+                string.Write(key.GetName())
+
+        elif isinstance(obj, ROOT.TH1):
+            # descendant of TH1 -> merge it
+            print("[INFO] Merging histogram {}/{}".format(path, obj.GetName()))
+            h1 = obj.Clone()
+            # loop over all source files and add the content of the
+            # corresponding histogram to the one pointed to by "h1"
+            for fname in sourcefiles[1:]:
+                f = ROOT.TFile.Open(fname, "READ")
+                # make sure we are at the correct directory level by cd'ing to path
+                f.cd(path)
+                key2 = ROOT.gDirectory.GetListOfKeys().FindObject(h1.GetName())
+                if key2:
+                    h2 = key.ReadObj()
+                    h1.Add(h2)
+                    del h2
+                f.Close()
+            target.cd()
+            h1.Write(key.GetName())
+        
+        elif isinstance(obj, ROOT.TTree):
+            tree_name = obj.GetName()
+            tchain = ROOT.TChain(tree_name)
+            full_tree_path = "{}/{}".format(path, tree_name)
+            print("[INFO] Linking trees in {} files under '{}'...".format(len(sourcefiles), full_tree_path))
+            for fname in sourcefiles:
+                if not tchain.AddFile(fname, ROOT.TTree.kMaxEntries, full_tree_path):
+                    raise RuntimeError('[ERROR] Could not connect tree {} in file {} to TChain!'.format(full_tree_path, fname))
+                # test the links
+                if check:
+                    num_entries = tchain.GetEntries()
+                    print("[INFO] Linking successful. Combined TChain yielded {} entries.".format(num_entries))
+            target.cd()
+            tchain.Write()
+        
+        elif isinstance(obj, ROOT.TDirectory):
+            # it's a subdirectory
+            print("[INFO] Found subdirectory " + obj.GetName())
+            
+            # create a new subdir of same name and title in the target file
+            target.cd()
+            newdir = target.mkdir(obj.GetName(), obj.GetTitle())
+            
+            # newdir is now the starting point of another round of merging
+            # newdir still knows its depth within the target file via
+            # GetPath(), so we can still figure out where we are in the recursion
+            MergeRootFiles(newdir, sourcefiles, check=check)
+            
+        else:
+            print("[WARNING] Unknown object type, name: " + obj.GetName() + " title: " + obj.GetTitle())
+    target.SaveSelf(ROOT.kTRUE)
+    ROOT.TH1.AddDirectory(status)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("TARGET", help="output root file", type=str)
+    parser.add_argument("INPUT", help="Input root files or XRootD path e.g. root://cmsxrootd-kit.gridka.de//store/user/myuser/*.root", type=str, nargs='+')
+
+    parser.add_argument('-c', '--check', help="check that the linking was successful by calling GetEntries on the resulting TChain", action='store_true')
+    parser.add_argument('-f', '--overwrite', help="overwrite an existing output file", action='store_true')
+
+    args = parser.parse_args()
+    output_file = args.TARGET
+    input_paths = args.INPUT
+    filelist = []
+    for path in input_paths:
+        filelist += glob(path)
+    print("pseudo_hadd Target file: {}".format(output_file))
+    for i, filename in enumerate(filelist):
+        print("pseudo_hadd Source file {}: {}".format(i, filename))
+        
+    mode = "RECREATE" if args.overwrite else "NEW"
+    target = ROOT.TFile.Open(output_file, mode)
+    if not target:
+        raise IOError("Target file '{}' already exists!".format(output_file))
+    MergeRootFiles(target, filelist, args.check)
+    target.Close()
+

--- a/scripts/xrootdglob.py
+++ b/scripts/xrootdglob.py
@@ -1,0 +1,126 @@
+# from https://github.com/xrootd/xrootd/blob/master/bindings/python/libs/client/glob_funcs.py as of 19/Jan/2022
+# needed since xrootd is not the latest version
+
+#-------------------------------------------------------------------------------
+# Copyright (c) 2012-2018 by European Organization for Nuclear Research (CERN)
+# Author: Benjamin Krikler <b.krikler@cern.ch>
+#-------------------------------------------------------------------------------
+# This file is part of the XRootD software suite.
+#
+# XRootD is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# XRootD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this licence, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+#-------------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function
+
+from XRootD.client.filesystem import FileSystem
+
+import glob as gl
+import os
+import fnmatch
+import sys
+if sys.version_info[0] > 2:
+    from urllib.parse import urlparse
+else:
+    from urlparse import urlparse
+
+
+__all__ = ["glob", "iglob"]
+
+
+def split_url(url):
+    parsed_uri = urlparse(url)
+    domain = '{uri.scheme}://{uri.netloc}/'.format(uri=parsed_uri)
+    path = parsed_uri.path
+    return domain, path
+
+
+def iglob(pathname, raise_error=False):
+    """
+    Generates paths based on a wild-carded path, potentially via xrootd.
+    Multiple wild-cards can be present in the path.
+    Args:
+      pathname (str):  The wild-carded path to be expanded.
+      raise_error (bool):  Whether or not to let xrootd raise an error if
+          there's a problem.  If False (default), and there's a problem for a
+          particular directory or file, then that will simply be skipped,
+          likely resulting in an empty list.
+    Yields:
+      (str): A single path that matches the wild-carded string
+    """
+    # Let normal python glob try first
+    generator = gl.iglob(pathname)
+    path = next(generator, None)
+    if path is not None:
+        yield path
+        for path in generator:
+            yield path
+        return
+
+    # Else try xrootd instead
+    for path in xrootd_iglob(pathname, raise_error=raise_error):
+        yield path
+
+
+def xrootd_iglob(pathname, raise_error):
+    """Handles the actual interaction with xrootd
+    Provides a python generator over files that match the wild-card expression.
+    """
+    # Split the pathname into a directory and basename
+    dirs, basename = os.path.split(pathname)
+
+    if gl.has_magic(dirs):
+        dirs = list(xrootd_iglob(dirs, raise_error))
+    else:
+        dirs = [dirs]
+
+    for dirname in dirs:
+        host, path = split_url(dirname)
+        query = FileSystem(host)
+
+        if not query:
+            raise RuntimeError("Cannot prepare xrootd query")
+
+        status, dirlist = query.dirlist(path)
+        if status.error:
+            if not raise_error:
+                continue
+            raise RuntimeError("'{!s}' for path '{}'".format(status, dirname))
+
+        for entry in dirlist.dirlist:
+            filename = entry.name
+            if filename in [".", ".."]:
+                continue
+            if not fnmatch.fnmatchcase(filename, basename):
+                continue
+            yield os.path.join(dirname, filename)
+
+
+def glob(pathname, raise_error=False):
+    """
+    Creates a list of paths that match pathname.
+    Multiple wild-cards can be present in the path.
+    Args:
+      pathname (str):  The wild-carded path to be expanded.
+      raise_error (bool):  Whether or not to let xrootd raise an error if
+          there's a problem.  If False (default), and there's a problem for a
+          particular directory or file, then that will simply be skipped,
+          likely resulting in an empty list.
+    Returns:
+      (str): A single path that matches the wild-carded string
+    """
+    return list(iglob(pathname, raise_error=raise_error))
+


### PR DESCRIPTION
This commit adds the option to use TChains for combining the TTrees of the GC output files instead of hadding them.

Usage: Add `--pseudo-hadd` to the `excalibur.py` call, only working when using `xrootd` in se path instead of srm

The output is now only a few MB, as the source files form the job outputs (hopefully stored at nrg) are linked.
This gets rid of the hadd process and hence saves a lot of time after gc finishes. For me hadd with a target on ceph can take multiple hours for a single run Period (e.g. 2018 Run D > 200GB output). Pseudo hadd only takes a couple of seconds.

Using this compared to a local copy on the ceph mount also yields speed ups when reading the files, e.g. when using Lumberjack (25 cores).
For DY MC sample: 364.453 seconds (single file on ceph) to 159.888 seconds (309 files on nrg) 
For 2018 D:  262.997 seconds (single file on ceph) to 189.587 seconds (380 files on nrg) and less average cpu usage, because of no overhead from the ceph mount