### PR TITLE
add muon matching to defaultconfig.py

### DIFF
--- a/cfg/python/defaultconfig.py
+++ b/cfg/python/defaultconfig.py
@@ -137,8 +137,8 @@ def data(cfg, **kwargs):
 
 def mc(cfg, **kwargs):
     cfg['InputIsData'] = False
+    cfg['Processors'] = ['producer:GenParticleProducer']+cfg['Processors']
     cfg['Processors'] += [
-        'producer:GenParticleProducer',
         'producer:ValidZllGenJetsProducer',
         'producer:RecoJetGenPartonMatchingProducer',
         #'producer:GenJetGenPartonMatchingProducer',
@@ -589,11 +589,10 @@ def mcmm(cfg, **kwargs):
         # 'genmu2pt','genmu2eta','genmu2phi','genmu2mass',
         ]
     cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllGenJetsProducer'), 'producer:GenZmmProducer',)
-    cfg['Processors'] += [
-    #        'producer:GenZmmProducer', #Use this for Status 1 muons
-            #'producer:ValidGenZmmProducer', #Use this for original muons  # TODO: get working
-            'producer:RecoMuonGenParticleMatchingProducer',  # TODO: Check order of producers
-            ]
+    # add muon matching before the valid muon producer, so we can use the matched muons for better rochester corrections
+    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidMuonsProducer'), 'producer:RecoMuonGenParticleMatchingProducer')
+    # match all muons, not just valid, since we need the matching to produce valid muons out of the correcetd ones...
+    cfg['RecoMuonMatchingGenParticleMatchAllMuons'] = True
     cfg['Pipelines']['default']['Processors'] += [
         'filter:MinNGenMuonsCut',
         'filter:MaxNGenMuonsCut',


### PR DESCRIPTION
Now MC rochester corrections make use of the matched muons. This is recommended: https://gitlab.cern.ch/akhukhun/roccor/-/blob/master/README `double mcSF = rc.kSpreadMC(Q, pt, eta, phi, genPt, s=0, m=0); //(recommended), MC scale and resolution correction when matched gen muon is available` and already implemented in the Muon Corrections Producer in Artus.