### PR TITLE
Debug refactoring for most of the currently used Producers/Filters 

### DIFF
--- a/Compile/interface/Filters/ZJetCutsFilter.h
+++ b/Compile/interface/Filters/ZJetCutsFilter.h
@@ -7,15 +7,15 @@
 /**
  * Filter class with cuts for ZJet analysis.
  *
- * min nleptons (el + mu) 
+ * min nleptons (el + mu)
  * max nleptons (el + mu)
- * leadinglep pt 
- * min nmuons    ***Not needed anymore [stefan wayand]
- * max nmuons    ***Not needed anymore [stefan wayand]
- * muon pt       ***Not needed anymore [stefan wayand]
- * muon eta      ***Not needed anymore [stefan wayand]
- * electron pt   ***Not needed anymore [stefan wayand]
- * electron eta  ***Not needed anymore [stefan wayand]
+ * leadinglep pt
+ * min nmuons
+ * max nmuons
+ * muon pt
+ * muon eta
+ * electron pt
+ * electron eta
  * leading jet pt
  * leading jet eta
  * z pt
@@ -23,7 +23,7 @@
  * alpha (second jet pt to z pt)
  */
 //////////////////
-// Min nLeptons //
+// Min nLeptons // +++CURRENTLY NOT USED+++
 //////////////////
 class MinNLeptonsCut : public ZJetFilterBase
 {
@@ -42,7 +42,15 @@ class MinNLeptonsCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return ( (product.m_validMuons.size() + product.m_validElectrons.size()) >= nLeptonsMin);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Number of m_validLaptons: " << product.m_validLeptons.size() << ", Cut: " << nLeptonsMin ;
+        if (product.m_validLeptons.size() >= nLeptonsMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << "not passed!";
+            return false;
+        }
     }
 
   private:
@@ -50,7 +58,7 @@ class MinNLeptonsCut : public ZJetFilterBase
 };
 
 //////////////////
-// Max nLeptons //
+// Max nLeptons // +++CURRENTLY NOT USED+++
 //////////////////
 class MaxNLeptonsCut : public ZJetFilterBase
 {
@@ -69,7 +77,15 @@ class MaxNLeptonsCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return ( (product.m_validMuons.size() + product.m_validElectrons.size()) <= nLeptonsMax);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Number of m_validLaptons: " << product.m_validLeptons.size() << ", Cut: " << nLeptonsMax ;
+        if (product.m_validLeptons.size() <= nLeptonsMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << "not passed!";
+            return false;
+        }
     }
 
   private:
@@ -78,7 +94,7 @@ class MaxNLeptonsCut : public ZJetFilterBase
 
 
 ///////////////////////
-// leading lepton Pt //
+// leading lepton Pt // +++CURRENTLY NOT USED+++
 ///////////////////////
 class LeadingLeptonPtCut : public ZJetFilterBase
 {
@@ -97,9 +113,12 @@ class LeadingLeptonPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "leadingLeptonPtMin: " << leadingLeptonPtMin;
+        LOG(WARNING) << "THIS CUT IS OUTDATED AND HAS TO BE REVIEWED!";
         // Only the first two muons need to pass this cut
 	if (product.m_validMuons.size() > 0 && product.m_validMuons[0]->p4.Pt() > leadingLeptonPtMin) return true;
-        if (product.m_validElectrons.size() > 0 && product.m_validElectrons[0]->p4.Pt() > leadingLeptonPtMin) return true;  
+        if (product.m_validElectrons.size() > 0 && product.m_validElectrons[0]->p4.Pt() > leadingLeptonPtMin) return true;
         return false;
     }
 
@@ -127,7 +146,15 @@ class MinNMuonsCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_validMuons.size() >= nMuonsMin);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Number of m_validMuons: " << product.m_validMuons.size() << " >= " << nMuonsMin;
+        if (product.m_validMuons.size() >= nMuonsMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -154,7 +181,15 @@ class MaxNMuonsCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_validMuons.size() <= nMuonsMax);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Number of m_validMuons: " << product.m_validMuons.size() << " <= " << nMuonsMax;
+        if (product.m_validMuons.size() <= nMuonsMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -175,10 +210,12 @@ class MuonPtCut : public ZJetFilterBase
     {
         ZJetFilterBase::Init(settings);
         muonPtMin = settings.GetCutMuonPtMin();
-        if (settings.GetCutMuonSubPtMin() != -1.0) {
+        if (settings.GetCutMuonSubPtMin() != -1.0) { // -1.0 is the default value
           muonSubPtMin = settings.GetCutMuonSubPtMin();
+          LOG(DEBUG) << "Asymmetric muon pt cut used with: " << muonSubPtMin;
         } else {
-          muonSubPtMin = muonPtMin;
+          muonSubPtMin = muonPtMin;  // if not set, use symmetric lepton cut
+          LOG(DEBUG) << "Use symmetric muon pt cut with: " << muonSubPtMin;
         }
     }
 
@@ -186,13 +223,23 @@ class MuonPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        // Only the first two muons need to pass this cut
-        bool allPassed = true;
-        allPassed = allPassed && product.m_validMuons[0]->p4.Pt() > muonPtMin;
-        allPassed = product.m_validMuons.size() >= 2
-                        ? (allPassed && product.m_validMuons[1]->p4.Pt() > muonSubPtMin)
-                        : allPassed;
-        return allPassed;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutMuonPtMin: " << muonPtMin << ", CutMuonSubPtMin: " << muonSubPtMin;
+        // Only the two muons of the Z lepton need to pass this cut
+        if (product.m_zValid == false) {
+            LOG(FATAL) << "No valid Z! Please check if the ValidZ cut was already applied.";
+        }
+        if (settings.GetDebugVerbosity() > 0) {
+            LOG(DEBUG) << "leading: " << product.m_zLeptons.first->p4;
+            LOG(DEBUG) << "sub-leading: " << product.m_zLeptons.second->p4;
+        }
+        if (product.m_zLeptons.first->p4.Pt() > muonPtMin && product.m_zLeptons.second->p4.Pt() > muonSubPtMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -220,13 +267,23 @@ class MuonEtaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        // Only the first two muons need to pass this cut
-        bool allPassed = true;
-        allPassed = allPassed && std::abs(product.m_validMuons[0]->p4.Eta()) < muonEtaMax;
-        allPassed = product.m_validMuons.size() >= 2
-                        ? (allPassed && std::abs(product.m_validMuons[1]->p4.Eta()) < muonEtaMax)
-                        : allPassed;
-        return allPassed;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutMuonEtaMax: " << muonEtaMax;
+        // Only the two muons of the Z lepton need to pass this cut
+        if (product.m_zValid == false) {
+            LOG(FATAL) << "No valid Z! Please check if the ValidZ cut was already applied.";
+        }
+        if (settings.GetDebugVerbosity() > 0) {
+            LOG(DEBUG) << "leading: " << product.m_zLeptons.first->p4;
+            LOG(DEBUG) << "sub-leading: " << product.m_zLeptons.second->p4;
+        }
+        if (product.m_zLeptons.first->p4.Eta() < muonEtaMax && product.m_zLeptons.second->p4.Eta() < muonEtaMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -249,8 +306,10 @@ class ElectronPtCut : public ZJetFilterBase
         electronPtMin = settings.GetCutElectronPtMin();
         if (settings.GetCutElectronSubPtMin() != -1.0) {
           electronSubPtMin = settings.GetCutElectronSubPtMin();
+          LOG(DEBUG) << "Asymmetric electron pt cut used with: " << electronSubPtMin;
         } else {
           electronSubPtMin = electronPtMin;
+          LOG(DEBUG) << "Use symmetric electron pt cut with: " << electronSubPtMin;
         }
     }
 
@@ -258,13 +317,23 @@ class ElectronPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        // Only the first two Electrons need to pass this cut
-        bool allPassed = true;
-        allPassed = allPassed && product.m_validElectrons[0]->p4.Pt() > electronPtMin;
-        allPassed = product.m_validElectrons.size() >= 2
-                        ? (allPassed && product.m_validElectrons[1]->p4.Pt() > electronSubPtMin)
-                        : allPassed;
-        return allPassed;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutElectronPtMin: " << electronPtMin << ", CutElectronSubPtMin: " << electronSubPtMin;
+        // Only the two electrons of the Z lepton need to pass this cut
+        if (product.m_zValid == false) {
+            LOG(FATAL) << "No valid Z! Please check if the ValidZ cut was already applied.";
+        }
+        if (settings.GetDebugVerbosity() > 0) {
+            LOG(DEBUG) << "leading: " << product.m_zLeptons.first->p4;
+            LOG(DEBUG) << "sub-leading: " << product.m_zLeptons.second->p4;
+        }
+        if (product.m_zLeptons.first->p4.Pt() > electronPtMin && product.m_zLeptons.second->p4.Pt() > electronSubPtMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -292,14 +361,24 @@ class ElectronEtaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        // Only the first two electrons need to pass this cut
-        bool allPassed = true;
-        allPassed = allPassed && std::abs(product.m_validElectrons[0]->p4.Eta()) < electronEtaMax;
-        allPassed =
-            product.m_validElectrons.size() >= 2
-                ? (allPassed && std::abs(product.m_validElectrons[1]->p4.Eta()) < electronEtaMax)
-                : allPassed;
-        return allPassed;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutElectronEtaMax: " << electronEtaMax;
+        // Only the two electrons of the Z lepton need to pass this cut
+        if (product.m_zValid == false) {
+            LOG(FATAL) << "No valid Z! Please check if the ValidZ cut was already applied.";
+        }
+        if (settings.GetDebugVerbosity() > 0) {
+            LOG(DEBUG) << "leading: " << product.m_zLeptons.first->p4;
+            LOG(DEBUG) << "sub-leading: " << product.m_zLeptons.second->p4;
+        }
+        if (product.m_zLeptons.first->p4.Eta() < electronEtaMax &&
+            product.m_zLeptons.second->p4.Eta() < electronEtaMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -326,9 +405,41 @@ class LeadingJetPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.GetValidJetCount(settings, event) > 0)
-                ? (product.GetValidPrimaryJet(settings, event)->p4.Pt() > leadingJetPtMin)
-                : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "LeadingJetPtMin: " << leadingJetPtMin;
+        LOG(DEBUG) << "LEVEL: " << settings.GetCorrectionLevel();
+        int valids = product.m_validJets.size();
+        int jetcount = product.GetValidJetCount(settings, event, settings.GetCorrectionLevel());
+        LOG(DEBUG) << "Number of m_validJets= " << valids << ", Number of corrected jets: " << jetcount <<"\n";
+        if (valids != jetcount) {
+            LOG(ERROR) << "++++ Jet lost! Please investigate!! ++++";  // TODO!
+        }
+        if (product.m_validJets.size() > 0) {
+            if (settings.GetDebugVerbosity() > 0) {
+                LOG(DEBUG) << "m_validJets:";
+                for (auto jet = product.m_validJets.begin(); jet != product.m_validJets.end();
+                     ++jet) {
+                    std::cout << (*jet)->p4 << std::endl;
+                }
+                LOG(DEBUG) << "\ncorrected jets: ";
+                for (int index = 0; index < jetcount; index++) {
+                    auto myjet =
+                        product.GetValidJet(settings, event, index, settings.GetCorrectionLevel());
+                    LOG(DEBUG) << "Index: " << index << ", " << myjet->p4;
+                }
+            }
+            LOG(DEBUG) << "Corrected leading Jet: " << product.GetValidPrimaryJet(settings, event)->p4;
+        } else {
+            LOG(DEBUG) << "+++++++ No valid jet left! ++++++++";
+            return false;
+        }
+        if (product.GetValidPrimaryJet(settings, event)->p4.Pt() > leadingJetPtMin){
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -355,9 +466,22 @@ class LeadingJetEtaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.GetValidJetCount(settings, event) > 0)
-                ? (std::abs(product.GetValidPrimaryJet(settings, event)->p4.Eta()) < leadingJetEtaMax)
-                : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutLeadingJetEtaMax: " << leadingJetEtaMax;
+
+        if ((product.GetValidJetCount(settings, event) > 0) == false) {
+            LOG(DEBUG) << "+++++++ No valid jet left! ++++++++";
+            return false;
+        }
+
+        LOG(DEBUG) << "abs(Eta): " << std::abs(product.GetValidPrimaryJet(settings, event)->p4.Eta());
+        if (std::abs(product.GetValidPrimaryJet(settings, event)->p4.Eta()) < leadingJetEtaMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -384,9 +508,22 @@ class LeadingJetYCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.GetValidJetCount(settings, event) > 0)
-                ? (std::abs(product.GetValidPrimaryJet(settings, event)->p4.Rapidity()) < leadingJetYMax)
-                : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutLeadingJetYMax: " << leadingJetYMax;
+
+        if ((product.GetValidJetCount(settings, event) > 0) == false) {
+            LOG(DEBUG) << "+++++++ No valid jet left! ++++++++";
+            return false;
+        }
+
+        LOG(DEBUG) << "abs(Rapidity): " << std::abs(product.GetValidPrimaryJet(settings, event)->p4.Rapidity());
+        if (std::abs(product.GetValidPrimaryJet(settings, event)->p4.Rapidity()) < leadingJetYMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -413,9 +550,21 @@ class PhistaretaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_zValid) 
-                    ? (product.GetPhiStarEta(event) > phistaretaMin)
-                    : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutPhistaretaMin: " << phistaretaMin;
+
+        if (product.m_zValid == false) {
+            LOG(FATAL) << "No valid Z! Please check if the ValidZ cut was already applied.";
+        }
+
+        LOG(DEBUG) << "PhiStarEta: " << product.GetPhiStarEta(event);
+        if (product.GetPhiStarEta(event) > phistaretaMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -442,7 +591,20 @@ class ZPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_z.p4.Pt() > zPtMin);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutZPtMin: " << zPtMin;
+        if (product.m_zValid == false) {
+            LOG(FATAL) << "No valid Z! Please check if the ValidZ cut was already applied.";
+        }
+
+        LOG(DEBUG) << "Z Pt: " << product.m_z.p4.Pt();
+        if (product.m_z.p4.Pt() > zPtMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -472,7 +634,24 @@ class ValidZCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_zValid && std::abs(product.m_z.p4.M()-ZMass)<ZMassRange);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Accepted Z mass: " << ZMass << " (pdg) +- " << settings.GetZMassRange()
+                   << " (mass window)";
+        LOG(DEBUG) << "Valid Z available? (0:No|1:Yes) " << product.m_zValid << ", reconstructed Z mass: "
+                   << product.m_z.p4.M();
+
+        if (product.m_zValid == false) {
+            LOG(DEBUG) << "No Z available! Cut not passed!";
+            return false;
+        }
+
+        if (std::abs(product.m_z.p4.M()-ZMass) < ZMassRange) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
   private:
     float ZMassRange = 0;
@@ -499,10 +678,22 @@ class BackToBackCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutBackToBack: " << backToBack;
+
         // ||Delta phi(Z, jet1)| - pi| < 0.34
         double deltaPhi = ROOT::Math::VectorUtil::DeltaPhi(
             product.m_z.p4, product.GetValidPrimaryJet(settings, event)->p4);
-        return M_PI - std::abs(deltaPhi) < backToBack;
+        LOG(DEBUG) << "Delta Phi: " << deltaPhi << " => pi - dPhi = " << M_PI - std::abs(deltaPhi);
+
+        if (M_PI - std::abs(deltaPhi) < backToBack) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
+
     }
 
   private:
@@ -510,7 +701,7 @@ class BackToBackCut : public ZJetFilterBase
 };
 
 ///////////
-// Alpha //
+// Alpha // +++CURRENTLY NOT USED+++
 ///////////
 class AlphaCut : public ZJetFilterBase
 {
@@ -529,11 +720,23 @@ class AlphaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutAlphaMax: " << alphaMax;
+
         // Always true if there is only one jet in the event
-        return (product.GetValidJetCount(settings, event) > 1)
-                   ? (product.GetValidJet(settings, event, 1)->p4.Pt() <
-                      alphaMax * product.m_z.p4.Pt())
-                   : true;
+        if ((product.GetValidJetCount(settings, event) > 1) == false) {
+            LOG(DEBUG) << "Not enough jets for alpha calculation!";
+            LOG(WARNING) << "Alpha Cut skipped!";
+            return true;
+        }
+
+        if (product.GetValidJet(settings, event, 1)->p4.Pt() < alphaMax * product.m_z.p4.Pt()) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -564,10 +767,12 @@ class JetIDCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-	    LOG(DEBUG) << "\n[JetIDCut]";
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
 	    LOG(DEBUG) << "CutJetID: " << settings.GetCutJetID() << ", CutJetIDVersion: " << settings.GetCutJetIDVersion();
+        LOG(DEBUG) << "Apply JetID on the first " << m_numJets << " jets.";
+
 	    if (m_jetIDEnumType == KappaEnumTypes::JetID::NONE) {
-	        LOG(WARNING) << "JetID Cut selected but no CutJetID given!";
+	        LOG(DEBUG) << "JetID Cut in pipeline but no CutJetID given!";
 	        LOG(DEBUG) << "JetID Cut skipped!\n";
 	        return true;
 	    } else {
@@ -588,7 +793,7 @@ class JetIDCut : public ZJetFilterBase
             }
        	}
 
-       	LOG(DEBUG) << "First " << m_numJets << " jets passed the JetID cut!\n";
+       	LOG(DEBUG) << "First (" << m_numJets << ") jets passed the JetID cut!\n";
         return true;  // first 'm_numJets' Jets passed ID
     }
 
@@ -619,14 +824,22 @@ class MinNGenMuonsCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Number of m_genMuons: " << product.m_genMuons.size() << " >= " << nMuonsMin;
+
 	/*unsigned int nMuons = 0;
 	for(unsigned int i = 0; i < product.m_genLeptonsFromBosonDecay.size();i++){
 		if(std::abs(product.m_genLeptonsFromBosonDecay.at(i)->pdgId) == 13)
 			nMuons++;
 	}*/
-	
 	//return(nMuons>=nMuonsMin);
-	return(product.m_genMuons.size()>=nMuonsMin);
+        if (product.m_genMuons.size() >= nMuonsMin) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -653,8 +866,17 @@ class MaxNGenMuonsCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "Number of m_genMuons: " << product.m_genMuons.size() << " <= " << nMuonsMax;
+
         //return (product.m_genLeptonsFromBosonDecay.size() <= nMuonsMax);
-	return (product.m_genMuons.size() <= nMuonsMax);
+        if (product.m_genMuons.size() <= nMuonsMax) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -662,7 +884,7 @@ class MaxNGenMuonsCut : public ZJetFilterBase
 };
 
 ////////////////
-// GenMuon Pt //
+// GenMuon Pt // 
 ////////////////
 class GenMuonPtCut : public ZJetFilterBase
 {
@@ -686,6 +908,16 @@ class GenMuonPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "+++ This filter is applied on ALL genMuons! +++";
+        if (settings.GetCutMuonSubPtMin() != -1.0) {
+            LOG(DEBUG) << "Using asymmetric pt cut:";
+            LOG(DEBUG) << "Leading muon pt cut:" << muonPtMin; 
+            LOG(DEBUG) << "Sub-leading muon pt cut: " << muonSubPtMin;
+        } else {
+            LOG(DEBUG) << "Using symmetric pt cut for leading and sub-leading muon: " << muonPtMin;
+        }
+
         // Only the first two muons need to pass this cut
         bool allPassed = true;
         /*allPassed = allPassed && product.m_genLeptonsFromBosonDecay.at(0)->p4.Pt() > muonPtMin;
@@ -696,6 +928,11 @@ class GenMuonPtCut : public ZJetFilterBase
         allPassed = product.m_genMuons.size() >= 2
                         ? (allPassed && product.m_genMuons[1]->p4.Pt() > muonSubPtMin)
                         : allPassed;
+        if (allPassed) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+        }
         return allPassed;
     }
 
@@ -705,7 +942,7 @@ class GenMuonPtCut : public ZJetFilterBase
 };
 
 //////////////////
-// Gen Muon Eta //
+// Gen Muon Eta //  
 //////////////////
 class GenMuonEtaCut : public ZJetFilterBase
 {
@@ -724,6 +961,9 @@ class GenMuonEtaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "+++ This filter is applied on ALL genMuons! +++";
+        LOG(DEBUG) << "CutMuonEtaNax: " << muonEtaMax;
         // Only the first two muons need to pass this cut
         bool allPassed = true;
         /*allPassed = allPassed && std::fabs(product.m_genLeptonsFromBosonDecay.at(0)->p4.Eta()) < muonEtaMax;
@@ -734,6 +974,11 @@ class GenMuonEtaCut : public ZJetFilterBase
         allPassed = product.m_genMuons.size() >= 2
                        ? (allPassed && std::fabs(product.m_genMuons[1]->p4.Eta()) < muonEtaMax)
                         : allPassed;
+        if (allPassed) {
+            LOG(DEBUG) << this->GetFilterId() << " passed!";
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+        }
         return allPassed;
     }
 
@@ -761,9 +1006,20 @@ class GenPhistaretaCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_genBosonLVFound)
-                    ? (product.GetGenPhiStarEta(event) > phistaretaMin)
-                    : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutPhiStaretaMin: " << phistaretaMin;
+        if (product.m_genBosonLVFound) {
+            LOG(DEBUG) << "GenPhiStarEta: " << product.GetGenPhiStarEta(event);                 
+            if (product.GetGenPhiStarEta(event) > phistaretaMin) {
+                LOG(DEBUG) << this->GetFilterId() << " passed!";
+                return true;
+            } else {
+                LOG(DEBUG) << this->GetFilterId() << " not passed!";
+                return false;
+            }
+        } else {
+            LOG(DEBUG) << "product.m_genBosonLVFound == false => Event vetoed!";
+        }
     }
 
   private:
@@ -790,7 +1046,17 @@ class GenZPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_genBosonLV.Pt() > zPtMin);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutZPtMin: " << zPtMin;
+        LOG(DEBUG) << "Pt: " << product.m_genBosonLV.Pt();
+
+        if (product.m_genBosonLV.Pt() > zPtMin) {
+            LOG(DEBUG) <<  this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
     }
 
   private:
@@ -798,7 +1064,7 @@ class GenZPtCut : public ZJetFilterBase
 };
 
 ////////////////////
-// Leading Jet Pt //
+//LeadingGenJet Pt//
 ////////////////////
 class LeadingGenJetPtCut : public ZJetFilterBase
 {
@@ -817,9 +1083,21 @@ class LeadingGenJetPtCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_simpleGenJets.size()>0)
-                ? (product.m_simpleGenJets.at(0)->p4.Pt() > leadingJetPtMin)
-                : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "GetCutLeadingJetPtMin: " << leadingJetPtMin;
+        if (product.m_simpleGenJets.size() > 0) {
+            LOG(DEBUG) << "Leading GenJet Pt: " << product.m_simpleGenJets.at(0)->p4.Pt();
+            if (product.m_simpleGenJets.at(0)->p4.Pt() > leadingJetPtMin) {
+                LOG(DEBUG) <<  this->GetFilterId() << " passed!";
+                return true;
+            } else {
+                LOG(DEBUG) << this->GetFilterId() << " not passed!";
+                return false;
+            }
+        } else {
+            LOG(DEBUG) << "No m_simpleGenJets available!";
+            return false;
+        }
     }
 
   private:
@@ -827,7 +1105,7 @@ class LeadingGenJetPtCut : public ZJetFilterBase
 };
 
 //////////////////////////////
-// Leading Gen Jet Rapidity //
+// Leading Gen Jet Rapidity // 
 //////////////////////////////
 class LeadingGenJetYCut : public ZJetFilterBase
 {
@@ -846,9 +1124,21 @@ class LeadingGenJetYCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_simpleGenJets.size()>0)
-                ? (std::abs(product.m_simpleGenJets.at(0)->p4.Rapidity()) < leadingJetYMax)
-                : false;
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutLeadingJetYMax: " << leadingJetYMax;
+        if (product.m_simpleGenJets.size() > 0) {
+            LOG(DEBUG) << "Leading GenJet Rapidity: " << product.m_simpleGenJets.at(0)->p4.Rapidity();
+            if (product.m_simpleGenJets.at(0)->p4.Pt() < leadingJetYMax) {
+                LOG(DEBUG) <<  this->GetFilterId() << " passed!";
+                return true;
+            } else {
+                LOG(DEBUG) << this->GetFilterId() << " not passed!";
+                return false;
+            }
+        } else {
+            LOG(DEBUG) << "No m_simpleGenJets available!";
+            return false;
+        }
     }
 
   private:
@@ -856,7 +1146,7 @@ class LeadingGenJetYCut : public ZJetFilterBase
 };
 
 ///////////
-// GenHT //
+// GenHT // 
 ///////////
 class GenHTCut : public ZJetFilterBase
 {
@@ -875,6 +1165,17 @@ class GenHTCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "CutGenHTMax: " << genhtMax;
+        LOG(DEBUG) << "GenHT: " << product.GetGenHT(event);
+        if (product.GetGenHT(event) < genhtMax) {
+            LOG(DEBUG) <<  this->GetFilterId() << " passed!";
+            return true;
+        } else {
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
+            return false;
+        }
+
         return (product.GetGenHT(event) < genhtMax);
     }
 
@@ -883,7 +1184,7 @@ class GenHTCut : public ZJetFilterBase
 };
 
 ///////////////
-// ValidGenZ //
+// ValidGenZ //  
 ///////////////
 
 class ValidGenZCut : public ZJetFilterBase
@@ -904,8 +1205,23 @@ class ValidGenZCut : public ZJetFilterBase
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override
     {
-        return (product.m_genBosonLVFound && std::fabs(product.m_genBosonLV.mass() - ZMass) < ZMassRange);
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+        LOG(DEBUG) << "ZMassRange: " << ZMassRange;
+        if (product.m_genBosonLVFound == false) {
+            LOG(DEBUG) << "No valid genBosonLVFound. Cut not passed!";
+            return false;
+        } else {
+            LOG(DEBUG) << "Z gen mass: " << product.m_genBosonLV.mass();
+            if(std::fabs(product.m_genBosonLV.mass() - ZMass) < ZMassRange) {
+                LOG(DEBUG) << this->GetFilterId() << " passed!";
+                return true;
+            } else {
+                LOG(DEBUG) << this->GetFilterId() << " not passed!";
+                return false;
+            }
+        }
     }
+
   private:
     float ZMassRange = 0;
     float ZMass = 90;
@@ -940,12 +1256,15 @@ class METFiltersFilter : public ZJetFilterBase {
     bool DoesEventPass(ZJetEvent const& event,
                        ZJetProduct const& product,
                        ZJetSettings const& settings) const override {
+        LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
       for (const size_t metFilterIndex : metFilterBitIndices) {
         if (!event.m_triggerObjects->passesMetFilter(metFilterIndex)) {
           // At least one required MetFilter is not passed. Reject Event.
+          LOG(DEBUG) << "METFilter with index: " << metFilterIndex << " not passed!";
           return false;
         }
       }
+      LOG(DEBUG) << "All METFilters passed!";
       return true;
     }
 

--- a/Compile/interface/Filters/ZJetCutsFilter.h
+++ b/Compile/interface/Filters/ZJetCutsFilter.h
@@ -48,7 +48,7 @@ class MinNLeptonsCut : public ZJetFilterBase
             LOG(DEBUG) << this->GetFilterId() << " passed!";
             return true;
         } else {
-            LOG(DEBUG) << this->GetFilterId() << "not passed!";
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
             return false;
         }
     }
@@ -83,7 +83,7 @@ class MaxNLeptonsCut : public ZJetFilterBase
             LOG(DEBUG) << this->GetFilterId() << " passed!";
             return true;
         } else {
-            LOG(DEBUG) << this->GetFilterId() << "not passed!";
+            LOG(DEBUG) << this->GetFilterId() << " not passed!";
             return false;
         }
     }
@@ -411,9 +411,6 @@ class LeadingJetPtCut : public ZJetFilterBase
         int valids = product.m_validJets.size();
         int jetcount = product.GetValidJetCount(settings, event, settings.GetCorrectionLevel());
         LOG(DEBUG) << "Number of m_validJets= " << valids << ", Number of corrected jets: " << jetcount <<"\n";
-        if (valids != jetcount) {
-            LOG(ERROR) << "++++ Jet lost! Please investigate!! ++++";  // TODO!
-        }
         if (product.m_validJets.size() > 0) {
             if (settings.GetDebugVerbosity() > 0) {
                 LOG(DEBUG) << "m_validJets:";
@@ -469,7 +466,7 @@ class LeadingJetEtaCut : public ZJetFilterBase
         LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
         LOG(DEBUG) << "CutLeadingJetEtaMax: " << leadingJetEtaMax;
 
-        if ((product.GetValidJetCount(settings, event) > 0) == false) {
+        if (!(product.GetValidJetCount(settings, event) > 0)) {
             LOG(DEBUG) << "+++++++ No valid jet left! ++++++++";
             return false;
         }
@@ -511,7 +508,7 @@ class LeadingJetYCut : public ZJetFilterBase
         LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
         LOG(DEBUG) << "CutLeadingJetYMax: " << leadingJetYMax;
 
-        if ((product.GetValidJetCount(settings, event) > 0) == false) {
+        if (!(product.GetValidJetCount(settings, event) > 0)) {
             LOG(DEBUG) << "+++++++ No valid jet left! ++++++++";
             return false;
         }
@@ -724,7 +721,7 @@ class AlphaCut : public ZJetFilterBase
         LOG(DEBUG) << "CutAlphaMax: " << alphaMax;
 
         // Always true if there is only one jet in the event
-        if ((product.GetValidJetCount(settings, event) > 1) == false) {
+        if (!(product.GetValidJetCount(settings, event) > 1)) {
             LOG(DEBUG) << "Not enough jets for alpha calculation!";
             LOG(WARNING) << "Alpha Cut skipped!";
             return true;

--- a/Compile/src/Producers/JetSorter.cc
+++ b/Compile/src/Producers/JetSorter.cc
@@ -11,16 +11,9 @@ void JetSorter::Produce(ZJetEvent const& event,
     for (std::map<std::string, std::vector<std::shared_ptr<KJet>>>::const_iterator itlevel =
              product.m_correctedZJets.begin();
         itlevel != product.m_correctedZJets.end(); ++itlevel) {
-	if(settings.GetDebugVerbosity() > 1) {
-            LOG(DEBUG) << "corr lvl: " << itlevel->first;
-            LOG(DEBUG) << "size before sort: " << product.m_correctedZJets[itlevel->first].size();
-	}
         std::sort(product.m_correctedZJets[itlevel->first].begin(),
                   product.m_correctedZJets[itlevel->first].end(),
                   [](std::shared_ptr<KJet> jet1, std::shared_ptr<KJet> jet2)
                       -> bool { return jet1->p4.Pt() > jet2->p4.Pt(); });
-	if(settings.GetDebugVerbosity() > 1) {
-            LOG(DEBUG) << "size after sort: " << product.m_correctedZJets[itlevel->first].size();
-	}
     }
 }

--- a/Compile/src/Producers/JetSorter.cc
+++ b/Compile/src/Producers/JetSorter.cc
@@ -7,12 +7,20 @@ void JetSorter::Produce(ZJetEvent const& event,
                         ZJetSettings const& settings) const
 {
     // Iterate over all jet correction levels
+    LOG(DEBUG) << "\n[JetSorter]";
     for (std::map<std::string, std::vector<std::shared_ptr<KJet>>>::const_iterator itlevel =
              product.m_correctedZJets.begin();
-         itlevel != product.m_correctedZJets.end(); ++itlevel) {
+        itlevel != product.m_correctedZJets.end(); ++itlevel) {
+	if(settings.GetDebugVerbosity() > 1) {
+            LOG(DEBUG) << "corr lvl: " << itlevel->first;
+            LOG(DEBUG) << "size before sort: " << product.m_correctedZJets[itlevel->first].size();
+	}
         std::sort(product.m_correctedZJets[itlevel->first].begin(),
                   product.m_correctedZJets[itlevel->first].end(),
                   [](std::shared_ptr<KJet> jet1, std::shared_ptr<KJet> jet2)
                       -> bool { return jet1->p4.Pt() > jet2->p4.Pt(); });
+	if(settings.GetDebugVerbosity() > 1) {
+            LOG(DEBUG) << "size after sort: " << product.m_correctedZJets[itlevel->first].size();
+	}
     }
 }

--- a/Compile/src/Producers/NPUProducer.cc
+++ b/Compile/src/Producers/NPUProducer.cc
@@ -18,8 +18,8 @@ void NPUProducer::Init(ZJetSettings const& settings)
         LOG(FATAL) << "Error in NPUProducer: Could not open luminosity file: " << file;
 
     while (f >> run >> ls >> lum >> xsrms >> xsavg) {
-        LOG(DEBUG) << run << " " << ls << " " << lum << " " << xsavg << " " << xsrms << ": "
-                   << (xsavg * minbxsec * 1000.0f) << " +/- " << (xsrms * minbxsec * 1000.0f);
+        //LOG(DEBUG) << run << " " << ls << " " << lum << " " << xsavg << " " << xsrms << ": "
+        //           << (xsavg * minbxsec * 1000.0f) << " +/- " << (xsrms * minbxsec * 1000.0f);
 
         if (xsrms < 0)
             LOG(FATAL) << "Error in PileupTruthProducer: RMS = " << xsrms << " < 0";
@@ -37,7 +37,7 @@ void NPUProducer::Produce(ZJetEvent const& event,
     const unsigned long ls = event.m_eventInfo->nLumi;
     float npu = 0;
     float npurms = 0;
-
+    LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
     try {
         npu = m_pumean.at(run).at(ls);
         npurms = m_pumeanrms.at(run).at(ls);

--- a/Compile/src/Producers/TypeIMETProducer.cc
+++ b/Compile/src/Producers/TypeIMETProducer.cc
@@ -33,6 +33,7 @@ void TypeIMETProducer::Produce(ZJetEvent const& event,
                                ZJetProduct& product,
                                ZJetSettings const& settings) const
 {
+    LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";	
     // Iterate over the jet collection
     for (unsigned int corrLevelIndex = 0; corrLevelIndex < m_corrLevels.size(); ++corrLevelIndex) {
         KLV correction;

--- a/Compile/src/Producers/ZJetCorrectionsProducer.cc
+++ b/Compile/src/Producers/ZJetCorrectionsProducer.cc
@@ -159,7 +159,7 @@ void ZJetCorrectionsProducer::Produce(ZJetEvent const& event,
     // TODO(gfleig): Do we need more assertions?
     assert(event.m_pileupDensity);
     assert(event.m_vertexSummary);
-
+    LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
     CorrectJetCollection("None", "L1", m_l1, event, product, settings);
     if (settings.GetRC()) {
         CorrectJetCollection("None", "RC", m_rc, event, product, settings);


### PR DESCRIPTION
This PR adds and enhances debug outputs -- mainly in the ZJetCutsFilter.h. 
Additionally, Muon/Electron pt and eta cuts were reworked to use the two leptons from the Z boson and not the two leading leptons.