### PR TITLE
Veto JetEtaPhi-Cleaned Events

### DIFF
--- a/Compile/interface/Filters/ZJetCutsFilter.h
+++ b/Compile/interface/Filters/ZJetCutsFilter.h
@@ -526,6 +526,41 @@ class LeadingJetYCut : public ZJetFilterBase
     float leadingJetYMax = 0;
 };
 
+//////////////////////
+// JetEtaPhiCleaner //
+//////////////////////
+class JetEtaPhiCleanerCut : public ZJetFilterBase {
+    public:
+        std::string GetFilterId() const override { return "JetEtaPhiCleanerCut"; }
+        JetEtaPhiCleanerCut() : ZJetFilterBase() {}
+
+        void Init(ZJetSettings const& settings) override {
+            ZJetFilterBase::Init(settings);
+            vetoCleanedEvents = settings.GetCutVetoCleanedEvents();
+        }
+
+        bool DoesEventPass(ZJetEvent const& event,
+                       ZJetProduct const& product,
+                       ZJetSettings const& settings) const override {
+            LOG(DEBUG) << "\n[" << this->GetFilterId() << "]";
+            LOG(DEBUG) << "CutVetoCleanedEvents: (0:no veto|1:veto events if cleaned) " << vetoCleanedEvents;
+            if (vetoCleanedEvents) {
+                if (product.m_etaPhiCleaned == true) {
+                    LOG(DEBUG) << "Event vetoed due to " << this->GetFilterId();
+                    return false;
+                } else {
+                    LOG(DEBUG) << "No (relevant) Jet cleaned. " <<  this->GetFilterId() << " passed!";
+                    return true;
+                }
+            } else {
+                LOG(DEBUG) << "Object-based JetEtaPhiCleaner selected. Skipping the filter.";
+                return true;
+        }
+        }
+    private:
+        bool vetoCleanedEvents = false;
+};
+
 ////////////////
 // Phistareta //
 ////////////////

--- a/Compile/interface/Producers/JetCleaner.h
+++ b/Compile/interface/Producers/JetCleaner.h
@@ -42,16 +42,16 @@ class JetCleanerBase : public ZJetProducerBase {
  * Therefore, it is necessary to first find the leading jet if the event should
  * be vetoed beacause of the removal of the first N leading jets.
  *
- * For this, the allready implemented functionality is reused ( I know it is 
+ * For this, the already implemented functionality is reused ( I know it is 
  * ugly but as ever: time is short, sorry ...)
  * I copy and pasted the loop and check whether there are N jets with greater
  * pT then the one which should be removed. This has to be done in a separate
- * loop since the immidiate removal would prevent this.
+ * loop since the immediate removal would prevent this.
  * => we set the veto flag, if no N jets can be found that are grater than the 
  * one which is checked.
  *
- * In the end, the remove is always gets a false since this should only happen 
- * in the next loop...
+ * In the end, the remove always gets a false returend since this should only 
+ * happen in the next loop...
  *****************************************************************************/
         std::string targetLevel;
         if (settings.GetInputIsData()) {

--- a/Compile/interface/Producers/JetCleaner.h
+++ b/Compile/interface/Producers/JetCleaner.h
@@ -27,19 +27,100 @@ class JetCleanerBase : public ZJetProducerBase {
                  ZJetProduct& product,
                  ZJetSettings const& settings) const override {
 
+        LOG(DEBUG) << "\n[" << this->GetProducerId() << "]";                       
+        if (settings.GetCutVetoCleanedEvents()) {
+            LOG(DEBUG) << "Check the first "<< settings.GetCutVetoNJets() 
+                       << " jets (all have to be above " << settings.GetCutVetoJetsAbove()
+                       << "GeV) for the JetEtaPhiCleanerCut.";
+        }
+
+/******************************************************************************
+ * For JEC it is necessary to check if the leading jet at full correction
+ * level is removed by the JetEtaPhiCleaner.
+ * Unfortunately the jets must not be sorted at this stage since the current
+ * implementation does not allow to do this before the TypeIMetProducer.
+ * Therefore, it is necessary to first find the leading jet if the event should
+ * be vetoed beacause of the removal of the first N leading jets.
+ *
+ * For this, the allready implemented functionality is reused ( I know it is 
+ * ugly but as ever: time is short, sorry ...)
+ * I copy and pasted the loop and check whether there are N jets with greater
+ * pT then the one which should be removed. This has to be done in a separate
+ * loop since the immidiate removal would prevent this.
+ * => we set the veto flag, if no N jets can be found that are grater than the 
+ * one which is checked.
+ *
+ * In the end, the remove is always gets a false since this should only happen 
+ * in the next loop...
+ *****************************************************************************/
+        std::string targetLevel;
+        if (settings.GetInputIsData()) {
+            targetLevel = "L1L2L3Res";  // highest corr level
+            LOG(DEBUG) << "Input is data: use L1L2L3Res for vetoing...";
+        } else {
+            targetLevel = "L1L2L3";  // for MC, use L1L2L3
+            LOG(DEBUG) << "Input is MC: use L1L2L3 for vetoing...";
+        }
         // Iterate over all JEC levels
         for (std::pair<const std::string, std::vector<std::shared_ptr<KJet>>>& jecLevelJetCollection : product.m_correctedZJets) {
+            if (settings.GetDebugVerbosity() > 1) {
+                LOG(DEBUG) << "Cleaning " << jecLevelJetCollection.first;
+                LOG(DEBUG) << "Before: " << jecLevelJetCollection.second.size() << " Jets";
+            }
+            // check if N leading jets are cleaned at highest corr level
+            if (settings.GetCutVetoCleanedEvents() && jecLevelJetCollection.first == targetLevel) {
+                jecLevelJetCollection.second.erase(
+                    std::remove_if(
+                        jecLevelJetCollection.second.begin(),
+                        jecLevelJetCollection.second.end(),
+                        [&, this](auto jetSharedPtr){
+                            bool removeJet = !this->DoesJetPass(jetSharedPtr.get(), event, product, settings);  // jet removed if true -> jet does not pass
+                            if (settings.GetCutVetoCleanedEvents() && jecLevelJetCollection.first == targetLevel && !product.m_etaPhiCleaned) {  // only check on max corr level
+                                auto jet_pt = jetSharedPtr.get()->p4.Pt();
+                                int count = 0;
+                                if ( jet_pt > settings.GetCutVetoJetsAbove()  // check all jets above value
+                                    && (removeJet) ) {
+                                    // loop over all jets and check the index of the one to be removed...
+                                    for (auto jet = jecLevelJetCollection.second.begin(); jet != jecLevelJetCollection.second.end() && !product.m_etaPhiCleaned; jet++) {
+                                        if ( (*jet)->p4.Pt() > jet_pt ) {
+                                            count++;
+                                        }
+                                    }
+                                    if ( count < settings.GetCutVetoNJets() && !product.m_etaPhiCleaned ) { // a relevant jet was cleaned => Veto event!
+                                        product.m_etaPhiCleaned = true;
+                                        if (settings.GetDebugVerbosity() > 1) {
+                                            LOG(DEBUG) << "VetoCleanedEvent: True ";
+                                            LOG(DEBUG) << "LEVEL: " << jecLevelJetCollection.first;
+                                            LOG(DEBUG) << "The " << count + 1 << ". jet will be cleaned! P4:" << jetSharedPtr.get()->p4;
+                                        }
+                                    }
+                                }
+                            }
+                            return false;
+                        }
+                    ),
+                    jecLevelJetCollection.second.end()
+                );
+            }
+
             // remove all jets for which DoesJetPass() returns false
             jecLevelJetCollection.second.erase(
                 std::remove_if(
                     jecLevelJetCollection.second.begin(),
                     jecLevelJetCollection.second.end(),
                     [&, this](auto jetSharedPtr){
-                        return !this->DoesJetPass(jetSharedPtr.get(), event, product, settings);
+                        bool removeJet = !this->DoesJetPass(jetSharedPtr.get(), event, product, settings);
+                        if (settings.GetDebugVerbosity() > 1 && removeJet) {
+                            LOG(DEBUG) << "Remove: LEVEL: " << jecLevelJetCollection.first << (jetSharedPtr.get()->p4);
+                        }
+                        return removeJet;
                     }
                 ),
                 jecLevelJetCollection.second.end()
             );
+                if (settings.GetDebugVerbosity() > 1) {
+                    LOG(DEBUG) << "After: " << jecLevelJetCollection.second.size() << " Jets";
+                }
         }
     };
 

--- a/Compile/interface/ZJetProduct.h
+++ b/Compile/interface/ZJetProduct.h
@@ -63,6 +63,9 @@ class ZJetProduct : public KappaProduct
     RMFLV m_truez;
     bool m_truezfound = false;
 
+    // Flag for JetEtaPhi Cleaner
+    bool m_etaPhiCleaned = false;
+
     /////////////////////////////
     // Functions for Consumers //
     /////////////////////////////

--- a/Compile/interface/ZJetSettings.h
+++ b/Compile/interface/ZJetSettings.h
@@ -93,6 +93,9 @@ class ZJetSettings : public KappaSettings
     IMPL_SETTING(float, CutGenHTMax)
     IMPL_SETTING(float, GenZMassRange)
     IMPL_SETTING(std::string, CutEtaPhiCleaningFile)
+    IMPL_SETTING_DEFAULT(bool, CutVetoCleanedEvents, false)  // true: cleaned events are vetoed according to the next two settings
+    IMPL_SETTING_DEFAULT(float, CutVetoJetsAbove, -1.0)  // default: all        
+    IMPL_SETTING_DEFAULT(int, CutVetoNJets, 1)  // default: only check leading jet; to check all jets, use 999
     IMPL_SETTING_DEFAULT(std::string, CutJetID, "none")
     IMPL_SETTING_DEFAULT(std::string, CutJetIDVersion, "none")
     IMPL_SETTING_DEFAULT(unsigned, CutJetIDFirstNJets, 1)

--- a/Compile/interface/ZJetSettings.h
+++ b/Compile/interface/ZJetSettings.h
@@ -95,7 +95,7 @@ class ZJetSettings : public KappaSettings
     IMPL_SETTING(std::string, CutEtaPhiCleaningFile)
     IMPL_SETTING_DEFAULT(bool, CutVetoCleanedEvents, false)  // true: cleaned events are vetoed according to the next two settings
     IMPL_SETTING_DEFAULT(float, CutVetoJetsAbove, -1.0)  // default: all        
-    IMPL_SETTING_DEFAULT(int, CutVetoNJets, 1)  // default: only check leading jet; to check all jets, use 999
+    IMPL_SETTING_DEFAULT(int, CutVetoNJets, 1)  // default: only check leading jet
     IMPL_SETTING_DEFAULT(std::string, CutJetID, "none")
     IMPL_SETTING_DEFAULT(std::string, CutJetIDVersion, "none")
     IMPL_SETTING_DEFAULT(unsigned, CutJetIDFirstNJets, 1)

--- a/Compile/src/ZJetFactory.cc
+++ b/Compile/src/ZJetFactory.cc
@@ -143,6 +143,8 @@ FilterBaseUntemplated* ZJetFactory::createFilter(std::string const& id)
         return new LeadingGenJetYCut();
     else if (id == LeadingJetYCut().GetFilterId())
         return new LeadingJetYCut();
+    else if (id == JetEtaPhiCleanerCut().GetFilterId())
+        return new JetEtaPhiCleanerCut();
     else if (id == ZPtCut().GetFilterId())
         return new ZPtCut();
     else if (id == GenZPtCut().GetFilterId())


### PR DESCRIPTION
With this PR the possibility is added to veto events where one of the first N leading jets (above a threshold) is cleaned by the JetEtaPhiCleaner.
It is activated with `CutVetoCleanedEvents=true`
The threshold can be chosen with `CutVetoJetsAbove=<VALUE>`
The number of jets to be checked: `CutVetoNJets=<VALUE>` (default is 1 -- veto the event when the leading jet is cleaned)
