### PR TITLE
Add JEC uncertainty splits

### DIFF
--- a/Compile/interface/Producers/ZJetCorrectionsProducer.h
+++ b/Compile/interface/Producers/ZJetCorrectionsProducer.h
@@ -15,8 +15,7 @@
    Required config tags:
    - JEC (path and prefix of the correction files)
    Optional:
-   - JetEnergyCorrectionUncertaintyParameters (default: empty, path of the uncertainty file)
-   - JetEnergyCorrectionUncertaintySource (default: "", name of the uncertainty)
+   - JetEnergyCorrectionUncertaintySource (default: "", name of the uncertainty, default is full)
    - JetEnergyCorrectionUncertaintyShift (default: 0.0, direction and scale of the uncertainty)
 
    Required packages (unfortunately, nobody knows a tag):

--- a/Compile/interface/Producers/ZJetCorrectionsProducer.h
+++ b/Compile/interface/Producers/ZJetCorrectionsProducer.h
@@ -14,10 +14,10 @@
 
    Required config tags:
    - JEC (path and prefix of the correction files)
-   Not yet implemented:
-   (- JetEnergyCorrectionUncertaintyParameters (default: empty))
-   (- JetEnergyCorrectionUncertaintySource (default ""))
-   (- JetEnergyCorrectionUncertaintyShift (default 0.0))
+   Optional:
+   - JetEnergyCorrectionUncertaintyParameters (default: empty, path of the uncertainty file)
+   - JetEnergyCorrectionUncertaintySource (default: "", name of the uncertainty)
+   - JetEnergyCorrectionUncertaintyShift (default: 0.0, direction and scale of the uncertainty)
 
    Required packages (unfortunately, nobody knows a tag):
    git cms-addpkg CondFormats/JetMETObjects

--- a/Compile/interface/ZJetSettings.h
+++ b/Compile/interface/ZJetSettings.h
@@ -46,7 +46,6 @@ class ZJetSettings : public KappaSettings
     IMPL_SETTING(bool, FlavourCorrections)
     IMPL_SETTING_DEFAULT(bool, ProvideL2ResidualCorrections, false)
     IMPL_SETTING_DEFAULT(bool, ProvideL2L3ResidualCorrections, false)
-    IMPL_SETTING_DEFAULT(bool, ProvideJECUncertainties, false)
 
     // JERSmearer
     IMPL_SETTING(std::string, JER)

--- a/Compile/src/Producers/ZJetCorrectionsProducer.cc
+++ b/Compile/src/Producers/ZJetCorrectionsProducer.cc
@@ -136,28 +136,24 @@ void ZJetCorrectionsProducer::Init(ZJetSettings const& settings)
         jecParameters.clear();
     }
     // JEU initialization
-    // JetEnergyCorrectionUncertaintyParameters is the file containing the uncertainties
-    // JetEnergyCorrectionUncertaintySource is the name of the uncertainty
-    if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
-		    (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
+    if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
 		{
             LOG(INFO) << "\t -- Enabling JEC Uncertainty...";
 			JetCorrectorParameters* jecUncertaintyParameters = nullptr;
-			if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
-				jecUncertaintyParameters = new JetCorrectorParameters(
-						settings.GetJetEnergyCorrectionUncertaintyParameters(),
-						settings.GetJetEnergyCorrectionUncertaintySource()
-				);
+            std::string fname_unc = settings.GetJec() + "_" + "UncertaintySources" + "_" + algoName + ".txt";
+			if (settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
+                LOG(FATAL) << "Undefined JetEnergyCorrectionUncertaintySource. Use 'Total' for full uncertainty.";
 			}
-			else {
-				jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
-			}
+			jecUncertaintyParameters = new JetCorrectorParameters(
+				fname_unc,
+				settings.GetJetEnergyCorrectionUncertaintySource()
+			);
 			if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
 				LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource() 
-				           << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
-			correctionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
-			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
-			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
+				           << " in file " << fname_unc;
+            LOG(DEBUG) << "\t\t" << "Using JEC uncertainty " << settings.GetJetEnergyCorrectionUncertaintySource();
+			LOG(DEBUG) << "\t\t" << "From file" << fname_unc;
+            correctionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
 		}
     else {
         LOG(INFO) << "\t -- Using mean JEC values. No JetEnergyCorrectionUncertaintyParameters and/or JetEnergyCorrectionUncertaintyShift supplied.";

--- a/Compile/src/Producers/ZJetCorrectionsProducer.cc
+++ b/Compile/src/Producers/ZJetCorrectionsProducer.cc
@@ -136,19 +136,31 @@ void ZJetCorrectionsProducer::Init(ZJetSettings const& settings)
         jecParameters.clear();
     }
     // JEU initialization
-    // so far no source differentiation is implemented
-    if (settings.GetProvideJECUncertainties()) {
-        LOG(INFO) << "\t -- JetCorrectionUncertainty enabled for " << algoName << " jets using the following JEU files";
-        LOG(INFO) << "\t -- " << settings.GetJec() << "_"
-                  << "Uncertainty" << "_" << algoName << ".txt";
-        JetCorrectorParameters* jecUncertaintyParameters = nullptr;
-        jecUncertaintyParameters = new JetCorrectorParameters(
-                    settings.GetJec() + "_" + "Uncertainty" + "_" + algoName + ".txt"
-            );
-        if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
-            LOG(FATAL)  << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource()
-                        << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
-        correctionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
+    // JetEnergyCorrectionUncertaintyParameters is the file containing the uncertainties
+    // JetEnergyCorrectionUncertaintySource is the name of the uncertainty
+    if ((! settings.GetJetEnergyCorrectionUncertaintyParameters().empty()) &&
+		    (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0))
+		{
+            LOG(INFO) << "\t -- Enabling JEC Uncertainty...";
+			JetCorrectorParameters* jecUncertaintyParameters = nullptr;
+			if (!settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
+				jecUncertaintyParameters = new JetCorrectorParameters(
+						settings.GetJetEnergyCorrectionUncertaintyParameters(),
+						settings.GetJetEnergyCorrectionUncertaintySource()
+				);
+			}
+			else {
+				jecUncertaintyParameters = new JetCorrectorParameters(settings.GetJetEnergyCorrectionUncertaintyParameters());
+			}
+			if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
+				LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource() 
+				           << " in file " << settings.GetJetEnergyCorrectionUncertaintyParameters();
+			correctionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
+			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintySource();
+			LOG(DEBUG) << "\t\t" << settings.GetJetEnergyCorrectionUncertaintyParameters();
+		}
+    else {
+        LOG(INFO) << "\t -- Using mean JEC values. No JetEnergyCorrectionUncertaintyParameters and/or JetEnergyCorrectionUncertaintyShift supplied.";
     }
 }
 

--- a/Compile/src/Producers/ZJetCorrectionsProducer.cc
+++ b/Compile/src/Producers/ZJetCorrectionsProducer.cc
@@ -136,25 +136,21 @@ void ZJetCorrectionsProducer::Init(ZJetSettings const& settings)
         jecParameters.clear();
     }
     // JEU initialization
-    if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0)
-		{
-            LOG(INFO) << "\t -- Enabling JEC Uncertainty...";
-			JetCorrectorParameters* jecUncertaintyParameters = nullptr;
-            std::string fname_unc = settings.GetJec() + "_" + "UncertaintySources" + "_" + algoName + ".txt";
-			if (settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
-                LOG(FATAL) << "Undefined JetEnergyCorrectionUncertaintySource. Use 'Total' for full uncertainty.";
-			}
-			jecUncertaintyParameters = new JetCorrectorParameters(
-				fname_unc,
-				settings.GetJetEnergyCorrectionUncertaintySource()
-			);
-			if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0))
-				LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource() 
-				           << " in file " << fname_unc;
-            LOG(DEBUG) << "\t\t" << "Using JEC uncertainty " << settings.GetJetEnergyCorrectionUncertaintySource();
-			LOG(DEBUG) << "\t\t" << "From file" << fname_unc;
-            correctionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
-		}
+    if (settings.GetJetEnergyCorrectionUncertaintyShift() != 0.0) {
+        LOG(INFO) << "\t -- Enabling JEC Uncertainty...";
+        JetCorrectorParameters* jecUncertaintyParameters = nullptr;
+        std::string fname_unc = settings.GetJec() + "_" + "UncertaintySources" + "_" + algoName + ".txt";
+        if (settings.GetJetEnergyCorrectionUncertaintySource().empty()) {
+            LOG(FATAL) << "Undefined JetEnergyCorrectionUncertaintySource. Use 'Total' for full uncertainty.";
+        }
+        jecUncertaintyParameters = new JetCorrectorParameters(fname_unc, settings.GetJetEnergyCorrectionUncertaintySource());
+        if ((!jecUncertaintyParameters->isValid()) || (jecUncertaintyParameters->size() == 0)) {
+            LOG(FATAL) << "Invalid definition " << settings.GetJetEnergyCorrectionUncertaintySource() << " in file " << fname_unc;
+        }
+        LOG(INFO) << "\t\t" << "Using JEC uncertainty " << settings.GetJetEnergyCorrectionUncertaintySource();
+        LOG(INFO) << "\t\t" << "From file" << fname_unc;
+        correctionUncertainty = new JetCorrectionUncertainty(*jecUncertaintyParameters);
+    }
     else {
         LOG(INFO) << "\t -- Using mean JEC values. No JetEnergyCorrectionUncertaintyParameters and/or JetEnergyCorrectionUncertaintyShift supplied.";
     }

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_DOWN.py.jinja2
@@ -100,7 +100,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul16_plus_hbm2_hbp12_qie11", "h2hot_mc"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = -1
 
     # MC specific

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_DOWN.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_UP.py.jinja2
@@ -100,7 +100,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul16_plus_hbm2_hbp12_qie11", "h2hot_mc"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = 1
 
     # MC specific

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JEC_UP.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JER_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JER_DOWN.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JER_UP.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpostVFP/mc_2016ulpostVFP_singlemuon_JER_UP.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_DOWN.py.jinja2
@@ -100,7 +100,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul16_plus_hbm2_hbp12_qie11", "h2hot_mc"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = -1
 
     # MC specific

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_DOWN.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_UP.py.jinja2
@@ -100,7 +100,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul16_plus_hbm2_hbp12_qie11", "h2hot_mc"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = 1
 
     # MC specific

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JEC_UP.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JER_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JER_DOWN.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JER_UP.py.jinja2
+++ b/cfg/excalibur/zjet2016ulpreVFP/mc_2016ulpreVFP_singlemuon_JER_UP.py.jinja2
@@ -61,7 +61,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_DOWN.py.jinja2
@@ -99,7 +99,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul17_plus_hep17_plus_hbpw89"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = -1
 
     # MC specific

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_DOWN.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_UP.py.jinja2
@@ -99,7 +99,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul17_plus_hep17_plus_hbpw89"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = 1
 
     # MC specific

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JEC_UP.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JER_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JER_DOWN.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JER_UP.py.jinja2
+++ b/cfg/excalibur/zjet2017ul/mc_2017ul_singlemuon_JER_UP.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_DOWN.py.jinja2
@@ -99,7 +99,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul18_plus_hem1516_and_hbp2m1"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = -1
 
     # MC specific

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_DOWN.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_UP.py.jinja2
@@ -99,7 +99,7 @@ def config():
     cfg['JetEtaPhiCleanerHistogramNames'] = ["h2hot_ul18_plus_hem1516_and_hbp2m1"]
     cfg['JetEtaPhiCleanerHistogramValueMaxValid'] = 9.9   # >=10 means jets should be invalidated
 
-    cfg['ProvideJECUncertainties'] = True
+    cfg['JetEnergyCorrectionUncertaintySource'] = '{{ jec_unc }}'
     cfg['JetEnergyCorrectionUncertaintyShift'] = 1
 
     # MC specific

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_UP.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JEC_UP.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JER_DOWN.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JER_DOWN.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####

--- a/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JER_UP.py.jinja2
+++ b/cfg/excalibur/zjet2018ul/mc_2018ul_singlemuon_JER_UP.py.jinja2
@@ -60,7 +60,7 @@ def config():
 
     # Jet Producers
     cfg['Processors'].insert(cfg['Processors'].index('producer:ZJetCorrectionsProducer')+1, 'producer:ValidZllJetsProducer')
-    cfg['Processors'].insert(cfg['Processors'].index('producer:ValidZllJetsProducer')+1, 'producer:ValidZllGenJetsProducer')
+    cfg['Processors'].insert(cfg['Processors'].index('producer:GenZmmProducer')+1, 'producer:ValidZllGenJetsProducer')
     cfg['Processors'] += ['producer:PUJetIDWeightProducer']
 
     ##### Specify input sources for Jets & Muons: #####


### PR DESCRIPTION
Not yet tested, since there's a dcache downtime.

How to use:
If an uncertainty file and uncertainty sift is provided, this shift will be used instead of the mean value for JECs.

Values:
   - JetEnergyCorrectionUncertaintyParameters (default: empty, path of the uncertainty file)
   - JetEnergyCorrectionUncertaintySource (default: "", name of the uncertainty)
   - JetEnergyCorrectionUncertaintyShift (default: 0.0, direction and scale of the uncertainty)